### PR TITLE
feat: 未保存設定時の警告追加、設定保存時の成否トースト通知の追加、設定値バリデーションの追加

### DIFF
--- a/RNGNewAuraNotifier.csproj
+++ b/RNGNewAuraNotifier.csproj
@@ -102,6 +102,7 @@
     </EmbeddedResource>
     <EmbeddedResource Include="src\SettingsForm.resx">
       <DependentUpon>SettingsForm.cs</DependentUpon>
+      <SubType>Designer</SubType>
     </EmbeddedResource>
     <None Include="Properties\Settings.settings">
       <Generator>SettingsSingleFileGenerator</Generator>

--- a/src/AppConfig.cs
+++ b/src/AppConfig.cs
@@ -2,6 +2,7 @@
 using System.IO;
 using System.Text.Json;
 using System.Text.Json.Serialization;
+using Windows.Storage.Search;
 
 namespace RNGNewAuraNotifier
 {
@@ -83,7 +84,13 @@ namespace RNGNewAuraNotifier
             }
             set
             {
-                _config.LogDir = value.Trim();
+                // required exists path
+                var trimmedValue = value?.Trim();
+                if (trimmedValue != null && !Directory.Exists(trimmedValue))
+                {
+                    throw new DirectoryNotFoundException($"The specified directory does not exist: {trimmedValue}");
+                }
+                _config.LogDir = trimmedValue;
                 Save();
             }
         }
@@ -101,7 +108,13 @@ namespace RNGNewAuraNotifier
             }
             set
             {
-                _config.DiscordWebhookUrl = value.Trim();
+                // required http or https
+                var trimmedValue = value?.Trim();
+                if (trimmedValue != null && !trimmedValue.StartsWith("http://") && !trimmedValue.StartsWith("https://"))
+                {
+                    throw new ArgumentException("DiscordWebhookUrl must start with http or https.");
+                }
+                _config.DiscordWebhookUrl = trimmedValue;
                 Save();
             }
         }

--- a/src/SettingsForm.Designer.cs
+++ b/src/SettingsForm.Designer.cs
@@ -28,6 +28,7 @@
         /// </summary>
         private void InitializeComponent()
         {
+            this.components = new System.ComponentModel.Container();
             System.ComponentModel.ComponentResourceManager resources = new System.ComponentModel.ComponentResourceManager(typeof(SettingsForm));
             this.label1 = new System.Windows.Forms.Label();
             this.textBoxWatchingFilePath = new System.Windows.Forms.TextBox();
@@ -41,67 +42,60 @@
             // label1
             // 
             this.label1.AutoSize = true;
-            this.label1.Location = new System.Drawing.Point(18, 67);
-            this.label1.Margin = new System.Windows.Forms.Padding(2, 0, 2, 0);
+            this.label1.Location = new System.Drawing.Point(30, 100);
             this.label1.Name = "label1";
-            this.label1.Size = new System.Drawing.Size(94, 12);
+            this.label1.Size = new System.Drawing.Size(138, 18);
             this.label1.TabIndex = 0;
             this.label1.Text = "Watching LogFile:";
             // 
             // textBoxWatchingFilePath
             // 
-            this.textBoxWatchingFilePath.Location = new System.Drawing.Point(20, 80);
-            this.textBoxWatchingFilePath.Margin = new System.Windows.Forms.Padding(2, 2, 2, 2);
+            this.textBoxWatchingFilePath.Location = new System.Drawing.Point(33, 120);
             this.textBoxWatchingFilePath.Multiline = true;
             this.textBoxWatchingFilePath.Name = "textBoxWatchingFilePath";
             this.textBoxWatchingFilePath.ReadOnly = true;
-            this.textBoxWatchingFilePath.Size = new System.Drawing.Size(437, 35);
+            this.textBoxWatchingFilePath.Size = new System.Drawing.Size(726, 50);
             this.textBoxWatchingFilePath.TabIndex = 1;
             // 
             // label2
             // 
             this.label2.AutoSize = true;
-            this.label2.Location = new System.Drawing.Point(18, 7);
-            this.label2.Margin = new System.Windows.Forms.Padding(2, 0, 2, 0);
+            this.label2.Location = new System.Drawing.Point(30, 10);
             this.label2.Name = "label2";
-            this.label2.Size = new System.Drawing.Size(72, 12);
+            this.label2.Size = new System.Drawing.Size(109, 18);
             this.label2.TabIndex = 2;
             this.label2.Text = "LogDirectory:";
             // 
             // textBoxLogDir
             // 
-            this.textBoxLogDir.Location = new System.Drawing.Point(20, 20);
-            this.textBoxLogDir.Margin = new System.Windows.Forms.Padding(2, 2, 2, 2);
+            this.textBoxLogDir.Location = new System.Drawing.Point(33, 30);
             this.textBoxLogDir.Multiline = true;
             this.textBoxLogDir.Name = "textBoxLogDir";
-            this.textBoxLogDir.Size = new System.Drawing.Size(437, 35);
+            this.textBoxLogDir.Size = new System.Drawing.Size(726, 50);
             this.textBoxLogDir.TabIndex = 3;
             // 
             // label3
             // 
             this.label3.AutoSize = true;
-            this.label3.Location = new System.Drawing.Point(18, 127);
-            this.label3.Margin = new System.Windows.Forms.Padding(2, 0, 2, 0);
+            this.label3.Location = new System.Drawing.Point(30, 190);
             this.label3.Name = "label3";
-            this.label3.Size = new System.Drawing.Size(121, 12);
+            this.label3.Size = new System.Drawing.Size(178, 18);
             this.label3.TabIndex = 4;
             this.label3.Text = "Discord Webhook URL:";
             // 
             // textBoxDiscordWebhookUrl
             // 
-            this.textBoxDiscordWebhookUrl.Location = new System.Drawing.Point(20, 140);
-            this.textBoxDiscordWebhookUrl.Margin = new System.Windows.Forms.Padding(2, 2, 2, 2);
+            this.textBoxDiscordWebhookUrl.Location = new System.Drawing.Point(33, 210);
             this.textBoxDiscordWebhookUrl.Multiline = true;
             this.textBoxDiscordWebhookUrl.Name = "textBoxDiscordWebhookUrl";
-            this.textBoxDiscordWebhookUrl.Size = new System.Drawing.Size(437, 35);
+            this.textBoxDiscordWebhookUrl.Size = new System.Drawing.Size(726, 50);
             this.textBoxDiscordWebhookUrl.TabIndex = 5;
             // 
             // buttonSave
             // 
-            this.buttonSave.Location = new System.Drawing.Point(392, 191);
-            this.buttonSave.Margin = new System.Windows.Forms.Padding(2, 2, 2, 2);
+            this.buttonSave.Location = new System.Drawing.Point(653, 286);
             this.buttonSave.Name = "buttonSave";
-            this.buttonSave.Size = new System.Drawing.Size(62, 25);
+            this.buttonSave.Size = new System.Drawing.Size(103, 38);
             this.buttonSave.TabIndex = 6;
             this.buttonSave.Text = "Save";
             this.buttonSave.UseVisualStyleBackColor = true;
@@ -109,9 +103,9 @@
             // 
             // SettingsForm
             // 
-            this.AutoScaleDimensions = new System.Drawing.SizeF(6F, 12F);
+            this.AutoScaleDimensions = new System.Drawing.SizeF(10F, 18F);
             this.AutoScaleMode = System.Windows.Forms.AutoScaleMode.Font;
-            this.ClientSize = new System.Drawing.Size(480, 233);
+            this.ClientSize = new System.Drawing.Size(800, 350);
             this.Controls.Add(this.buttonSave);
             this.Controls.Add(this.textBoxDiscordWebhookUrl);
             this.Controls.Add(this.label3);
@@ -121,10 +115,10 @@
             this.Controls.Add(this.label1);
             this.FormBorderStyle = System.Windows.Forms.FormBorderStyle.Fixed3D;
             this.Icon = ((System.Drawing.Icon)(resources.GetObject("$this.Icon")));
-            this.Margin = new System.Windows.Forms.Padding(2, 2, 2, 2);
             this.MaximizeBox = false;
             this.Name = "SettingsForm";
             this.Text = "RNGNewAuraNotifier Settings";
+            this.FormClosing += new System.Windows.Forms.FormClosingEventHandler(this.OnFormClosing);
             this.FormClosed += new System.Windows.Forms.FormClosedEventHandler(this.OnFormClosed);
             this.Load += new System.EventHandler(this.OnLoad);
             this.ResumeLayout(false);

--- a/src/SettingsForm.cs
+++ b/src/SettingsForm.cs
@@ -73,7 +73,7 @@ namespace RNGNewAuraNotifier
 
         private void OnFormClosing(object sender, FormClosingEventArgs e)
         {
-            var changed = lastSavedLogDir != textBoxLogDir.Text || lastSavedDiscordWebhookUrl != textBoxDiscordWebhookUrl.Text;
+            var changed = lastSavedLogDir != textBoxLogDir.Text.Trim() || lastSavedDiscordWebhookUrl != textBoxDiscordWebhookUrl.Text.Trim();
             if (!changed)
             {
                 return;

--- a/src/SettingsForm.cs
+++ b/src/SettingsForm.cs
@@ -1,10 +1,13 @@
-﻿using System.Windows.Forms;
+﻿using System;
+using System.Windows.Forms;
 
 namespace RNGNewAuraNotifier
 {
     public partial class SettingsForm : Form
     {
         private Timer timer;
+        private string lastSavedLogDir;
+        private string lastSavedDiscordWebhookUrl;
 
         public SettingsForm()
         {
@@ -14,7 +17,7 @@ namespace RNGNewAuraNotifier
         /// <summary>
         /// 設定画面がロードされたときの処理
         /// </summary>
-        private void OnLoad(object sender, System.EventArgs e)
+        private void OnLoad(object sender, EventArgs e)
         {
             // 設定ファイルから値を読み込む
             textBoxLogDir.Text = AppConfig.LogDir ?? Program.Watcher.GetLogDir(); // 設定ファイルで規定していない場合は実際の監視対象を取得
@@ -30,20 +33,65 @@ namespace RNGNewAuraNotifier
                 textBoxWatchingFilePath.Text = Program.Watcher.GetCurrentFile();
             };
             timer.Start();
+
+            lastSavedLogDir = textBoxLogDir.Text;
+            lastSavedDiscordWebhookUrl = textBoxDiscordWebhookUrl.Text;
+        }
+
+        private bool Save()
+        {
+            try
+            {
+                AppConfig.LogDir = !string.IsNullOrEmpty(textBoxLogDir.Text) ? textBoxLogDir.Text : null;
+                AppConfig.DiscordWebhookUrl = !string.IsNullOrEmpty(textBoxDiscordWebhookUrl.Text) ? textBoxDiscordWebhookUrl.Text : null;
+
+                Program.Watcher.Stop();
+                Program.Watcher = new VRChatLogWatcher(textBoxLogDir.Text);
+                Program.Watcher.Start();
+
+                lastSavedLogDir = textBoxLogDir.Text;
+                lastSavedDiscordWebhookUrl = textBoxDiscordWebhookUrl.Text;
+
+                Notifier.ShowToast("Settings Saved", "Settings have been saved successfully.");
+                return true;
+            }
+            catch (Exception ex)
+            {
+                MessageBox.Show($"Error saving settings: {ex.Message}", "Error", MessageBoxButtons.OK, MessageBoxIcon.Error);
+                return false;
+            }
         }
 
         /// <summary>
         /// 保存ボタンがクリックされたときの処理
         /// </summary>
         /// <remarks>設定ファイルに値を保存し、VRChatのログ監視を再起動する</remarks>
-        private void OnSaveButtonClicked(object sender, System.EventArgs e)
+        private void OnSaveButtonClicked(object sender, EventArgs e)
         {
-            AppConfig.LogDir = !string.IsNullOrEmpty(textBoxLogDir.Text) ? textBoxLogDir.Text : null;
-            AppConfig.DiscordWebhookUrl = !string.IsNullOrEmpty(textBoxDiscordWebhookUrl.Text) ? textBoxDiscordWebhookUrl.Text : null;
+            Save();
+        }
 
-            Program.Watcher.Stop();
-            Program.Watcher = new VRChatLogWatcher(textBoxLogDir.Text);
-            Program.Watcher.Start();
+        private void OnFormClosing(object sender, FormClosingEventArgs e)
+        {
+            var changed = lastSavedLogDir != textBoxLogDir.Text || lastSavedDiscordWebhookUrl != textBoxDiscordWebhookUrl.Text;
+            if (!changed)
+            {
+                return;
+            }
+
+            var result = MessageBox.Show("Some settings are not saved. Do you want to save them?", "Confirm", MessageBoxButtons.YesNoCancel, MessageBoxIcon.Question);
+            if (result == DialogResult.Yes)
+            {
+                var saved = Save();
+                if (!saved)
+                {
+                    e.Cancel = true; // 保存に失敗した場合は閉じない
+                }
+            }
+            else if (result == DialogResult.Cancel)
+            {
+                e.Cancel = true;
+            }
         }
 
         private void OnFormClosed(object sender, FormClosedEventArgs e)

--- a/src/VRChatLogWatcher.cs
+++ b/src/VRChatLogWatcher.cs
@@ -60,7 +60,6 @@ namespace RNGNewAuraNotifier
         );
 
         private const string NotifyTitle = "Successfully legitimized Aura!";
-        private const int AuraIdLength = 2;
 
         public VRChatLogWatcher(string logDirectory)
         {


### PR DESCRIPTION
- close #5 
- close #7 

## 未保存の設定がある場合にメッセージボックスを出す

![image](https://github.com/user-attachments/assets/bf7b37b8-0a5c-4dc1-a448-b2441c577816)

## 設定保存時、成功したらトースト通知を、失敗したらメッセージボックスを出す

![image](https://github.com/user-attachments/assets/99ae3b2f-1928-42e7-8c39-9c8da794fa85)

![image](https://github.com/user-attachments/assets/a418dc0e-ca58-47fc-a5f9-1284f8d50fae)

## 設定保存時のバリデーションを追加

以下を追加

- LogDir については、対象ディレクトリがない場合はエラー
- DiscordWebhookUrl については、`http:` もしくは `https:` から始まらない場合にエラー

## 謎の定数 AuraIdLength を削除

unused だったので消した