### PR TITLE
fix: コンソール出力のエンコーディングをUTF-8に設定

### DIFF
--- a/RNGNewAuraNotifier/Program.cs
+++ b/RNGNewAuraNotifier/Program.cs
@@ -1,5 +1,6 @@
 using System.Diagnostics;
 using System.Runtime.InteropServices;
+using System.Text;
 using RNGNewAuraNotifier.Core;
 using RNGNewAuraNotifier.Core.Config;
 using RNGNewAuraNotifier.UI.TrayIcon;
@@ -25,6 +26,7 @@ internal static partial class Program
         {
             AllocConsole();
             Console.SetOut(new StreamWriter(Console.OpenStandardOutput()) { AutoFlush = true });
+            Console.OutputEncoding = Encoding.UTF8;
         }
 
         Console.WriteLine("Program.Main");


### PR DESCRIPTION
現状のDebug時のコンソール出力は、エンコードがUTF-8ではないため、日本語等の2bytes文字が文字化けしてしまうことがある。
コンソール出力時のエンコードをUTF-8にすることで、これを解決する。