### PR TITLE
feat: April Fools 2026 Update対応

### DIFF
--- a/ElitesRNGAuraObserver/Core/Aura/AuraCategory.cs
+++ b/ElitesRNGAuraObserver/Core/Aura/AuraCategory.cs
@@ -69,4 +69,14 @@ internal enum AuraCategory
     /// SoulShatteringカテゴリ
     /// </summary>
     SoulShattering = 12,
+
+    /// <summary>
+    /// AprilFoolsカテゴリ
+    /// </summary>
+    AprilFools = 13,
+
+    /// <summary>
+    /// Collabカテゴリ
+    /// </summary>
+    Collab = 14,
 }

--- a/ElitesRNGAuraObserver/Resources/Auras.json
+++ b/ElitesRNGAuraObserver/Resources/Auras.json
@@ -1,5 +1,5 @@
 {
-  "Version": "2026.03.03",
+  "Version": "2026.05.03",
   "Auras": [
     {
       "ID": 0,
@@ -308,9 +308,9 @@
     {
       "ID": 38,
       "Name": "Solstice",
-      "Rarity": 360000,
-      "Category": 4,
-      "Special": false,
+      "Rarity": 36000,
+      "Category": 14,
+      "Special": true,
       "SubText": ""
     },
     {
@@ -848,6 +848,30 @@
       "Category": 6,
       "Special": false,
       "SubText": ""
+    },
+    {
+      "ID": 106,
+      "Name": "Particle System",
+      "Rarity": 11000,
+      "Category": 13,
+      "Special": true,
+      "SubText": "APRIL FOOLS EXCLUSIVE"
+    },
+    {
+      "ID": 107,
+      "Name": "Missing(Material)",
+      "Rarity": 101010,
+      "Category": 13,
+      "Special": true,
+      "SubText": "APRIL FOOLS EXCLUSIVE"
+    },
+    {
+      "ID": 108,
+      "Name": "Recursion",
+      "Rarity": 1010101,
+      "Category": 13,
+      "Special": true,
+      "SubText": "APRIL FOOLS EXCLUSIVE"
     }
   ]
 }


### PR DESCRIPTION
イベント期間限定のオーラ追加
 - Particle System
 - Missing(Material)
 - Recursion
 
ToNコラボに伴って、オーラの確率を変更
 - Solstice: 360,000 → 36,000