### PR TITLE
chore: エージェント向けドキュメントを整備 (CLAUDE.md / copilot-instructions.md)

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -1,0 +1,31 @@
+# Copilot code review instructions
+
+Elite's RNG Aura Observer is a Windows-only C# / WinForms desktop app (.NET 9)
+that tails VRChat logs and sends toast + Discord webhook notifications when an
+Aura is obtained. A separate `ElitesRNGAuraObserver.Updater` project self-updates
+from GitHub releases. There is no automated test project.
+
+Review for the points below. Keep comments specific and actionable.
+
+## Review priorities
+
+- **Secret handling.** The Discord webhook URL (`ConfigData.DiscordWebhookUrl`) is user-provided and sensitive. Flag any code that logs it, writes it to error/telemetry output, or embeds a real webhook/token as a literal.
+- **XML documentation.** StyleCop (`stylecop.json`) requires doc comments on *every* type and member, including `private` ones. Flag new/changed members that lack an XML doc comment — CI's `dotnet format --verify-no-changes` will otherwise fail.
+- **Log-parsing regex.** Detection depends on VRChat's exact log format (`NewAuraDetectionService.cs`, `AuthenticatedDetectionService.cs`). Flag regex changes that look narrower/broader than intended or that could silently stop matching real log lines.
+- **Watcher resilience.** `LogWatcher` and notification code run in background loops. Flag exceptions that can escape and kill the loop; network/notification calls should be wrapped in try/catch with logging, matching the existing pattern.
+- **Nullability.** `Nullable` is enabled. Flag dereferences of possibly-null values and unjustified `!` null-forgiving operators.
+- **File / IO and process handling.** The updater deletes directories, kills processes, downloads assets, and verifies a checksum digest before extracting. Flag removal of the checksum verification, path handling that could escape the target folder, or unhandled IO failures.
+- **Resource lifetime.** `IDisposable` types (`LogWatcher`, mutex, streams, `CancellationTokenSource`) must be disposed. Flag leaks or double-dispose.
+
+## Conventions enforced
+
+- 4-space indentation (spaces, not tabs), file-scoped namespaces, `using` directives outside the namespace with `System.*` first, newline at end of file. These are enforced by StyleCop + `dotnet format`; only comment on them when a change clearly violates them.
+- Conventional Commit prefixes (`feat:`, `fix:`, `chore:`, …) drive the release version bump.
+
+## Known non-issues — do not flag
+
+- Japanese XML doc comments and inline comments are intentional; do not ask to translate them to English.
+- Windows-only APIs (WinForms, registry access, `LibraryImport`/P/Invoke, UWP toast) are expected — do not suggest cross-platform alternatives.
+- `AllowUnsafeBlocks` and the console `Console.WriteLine` debug logging throughout are intentional design choices.
+- Absence of unit tests is known; do not request adding a test project as a blocking review item.
+- `Auras.json` is a large generated data catalog; do not review it line by line.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,65 @@
+# CLAUDE.md
+
+## Overview
+
+Elite's RNG Aura Observer is a Windows desktop app (C# / WinForms, .NET 9) that
+watches VRChat log files and, when the player obtains an Aura in the VRChat world
+"Elite's RNG Land", sends a Windows toast notification and a Discord webhook
+message. It runs in the background from the task tray and ships with a separate
+auto-updater. Windows-only.
+
+## Solution layout
+
+Two projects in `ElitesRNGAuraObserver.sln`:
+
+- `ElitesRNGAuraObserver/` — the main tray application (`WinExe`).
+  - `Program.cs` — entry point: single-instance mutex, exception handlers, update check, then `Application.Run(new TrayIcon())`.
+  - `Core/AuraObserverController.cs` — wires `LogWatcher` to the detection services.
+  - `Core/VRChat/LogWatcher.cs` — polls the newest `output_log_*.txt` every 1s and raises `OnNewLogLine`.
+  - `Core/VRChat/AuthenticatedDetectionService.cs`, `Core/Aura/NewAuraDetectionService.cs` — parse log lines (regex) into events.
+  - `Core/Notification/UwpNotificationService.cs`, `DiscordNotificationService.cs` — toast and webhook delivery.
+  - `Core/Config/` — `AppConfig` (config.json load/save), `ConfigData`, `RegistryManager` (startup registration).
+  - `Core/Aura/` — `Aura` record, `AuraCategory` enum, `JsonData` loader. Aura catalog is `Resources/Auras.json` (embedded), overridable by a local `Auras.json`.
+  - `Core/Updater/` — checks GitHub releases and launches the updater.
+  - `UI/` — `SettingsForm`, `TrayIcon`, custom controls.
+- `ElitesRNGAuraObserver.Updater/` — standalone self-contained (`win-x64`) console updater. Downloads the latest GitHub release asset, verifies its checksum digest, kills the running app, extracts, and relaunches.
+
+## Development commands
+
+- `dotnet restore ElitesRNGAuraObserver.sln` — restore packages.
+- `dotnet build ElitesRNGAuraObserver.sln /p:Configuration=Release` — build.
+- `dotnet publish ElitesRNGAuraObserver.sln -p:PublishProfile=Publish` — publish single-file output to `bin/Publish/`.
+- `dotnet format ElitesRNGAuraObserver.sln --verify-no-changes --severity warn` — style check. CI runs this exact command and fails on any diff; run it before committing.
+
+Build/publish must run on Windows (`net9.0-windows10.0.17763.0`, WinForms).
+
+## Testing
+
+There is no automated test project. Verify changes manually: build, run the app,
+and confirm detection/notification against real or sample VRChat logs. The
+Aura-detection regex in `NewAuraDetectionService.cs` depends on VRChat's exact log
+format — when changing it, test against an actual `output_log_*.txt` line.
+
+## Coding conventions
+
+- StyleCop.Analyzers is enabled with `stylecop.json`. Notably `documentPrivateElements`/`documentPrivateFields` are true, so **every** type and member — including `private` ones — needs an XML doc comment, or the style check fails.
+- 4-space indentation, spaces (no tabs). File-scoped namespaces. `using` directives outside the namespace, `System.*` first. Newline required at end of file.
+- `Nullable` and `ImplicitUsings` are enabled; respect nullable annotations.
+- XML doc comments and inline comments in this codebase are written in Japanese — match the existing language when editing.
+- Wrap notification / network calls (Discord, toast) in try/catch and log failures via `Console.WriteLine` rather than letting them crash the watcher loop, following the existing pattern.
+
+## Configuration & runtime data
+
+- User config is `config.json` under `%LocalAppData%\tomacheese\ElitesRNGAuraObserver`. An optional `config.path` file next to the exe redirects the config directory.
+- `ConfigData` holds the Discord webhook URL, toast on/off, VRChat log dir, and Auras.json dir. The webhook URL is a user secret — never log it or commit a real value.
+- `RegistryManager.EnsureStartupRegistration()` writes a Windows registry key for launch-at-startup.
+
+## CI / release
+
+- `.github/workflows/ci.yml` — on push/PR to `main`/`master`: restore, build, publish, upload artifacts, then the `dotnet format` style check.
+- `.github/workflows/release.yml` — on push to `main`/`master`: `mathieudutour/github-tag-action` bumps the version from Conventional Commit prefixes, then builds and publishes a GitHub Release zip.
+- Commit messages follow Conventional Commits (`feat:`, `fix:`, `chore:`, …); the prefix drives the release bump, so keep it accurate. Descriptions may be Japanese or English.
+
+## Documentation
+
+- User-facing docs live in `docs/en/` and `docs/ja/`; `README.md` / `README-ja.md` are the entry points. Update both language variants when changing user-facing behavior (install steps, settings, notifications).

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -19,7 +19,7 @@ Two projects in `ElitesRNGAuraObserver.sln`:
   - `Core/VRChat/AuthenticatedDetectionService.cs`, `Core/Aura/NewAuraDetectionService.cs` — parse log lines (regex) into events.
   - `Core/Notification/UwpNotificationService.cs`, `DiscordNotificationService.cs` — toast and webhook delivery.
   - `Core/Config/` — `AppConfig` (config.json load/save), `ConfigData`, `RegistryManager` (startup registration).
-  - `Core/Aura/` — `Aura` record, `AuraCategory` enum, `JsonData` loader. Aura catalog is `Resources/Auras.json` (embedded), overridable by a local `Auras.json`.
+  - `Core/Aura/` — `Aura` record, `AuraCategory` enum. `Core/Json/JsonData.cs` is the catalog loader. Aura catalog is `Resources/Auras.json` (embedded), overridable by a local `Auras.json`.
   - `Core/Updater/` — checks GitHub releases and launches the updater.
   - `UI/` — `SettingsForm`, `TrayIcon`, custom controls.
 - `ElitesRNGAuraObserver.Updater/` — standalone self-contained (`win-x64`) console updater. Downloads the latest GitHub release asset, verifies its checksum digest, kills the running app, extracts, and relaunches.


### PR DESCRIPTION
## 概要

生成 AI エージェント向けの指示ファイルを `CLAUDE.md` と `.github/copilot-instructions.md` の 2 点に標準化する。どちらも `master` には存在しなかったため新規作成。

## 変更内容

- **`CLAUDE.md`(新規)**: 実ソース・設定・CI を照合して作成。プロジェクト概要(.NET 9 / WinForms / Windows 専用)、ソリューション構成(本体 + Updater)、ビルド/publish/format コマンド、テスト方針(自動テストなし・手動検証)、コーディング規約(StyleCop による private 含む全メンバーの XML doc 必須など)、設定/ランタイムデータ(config.json、Discord Webhook URL の秘匿)、CI/リリース(Conventional Commits によるバージョン bump)を記載。
- **`.github/copilot-instructions.md`(新規)**: GitHub Copilot のコードレビュー用。レビュー重点(秘匿情報・XML doc・ログ解析 regex・ウォッチャーの堅牢性・nullability・IO/プロセス・IDisposable)と、誤検知しがちな既知の非問題(日本語コメント・Windows 専用 API・テスト非存在など)を明記。

## 検証した主な事実

- `TargetFramework` は `net9.0-windows10.0.17763.0`(両 csproj)。
- CI は `dotnet restore/build/publish` 後に `dotnet format --verify-no-changes --severity warn` を実行。
- `stylecop.json` で `documentPrivateElements`/`documentPrivateFields` が true。
- テストプロジェクトは存在しない(sln はアプリ 2 本のみ)。
- 設定は `%LocalAppData%\tomacheese\ElitesRNGAuraObserver\config.json`。

削除対象(AGENTS.md / GEMINI.md 等)は存在しなかった。

🤖 Generated with [Claude Code](https://claude.com/claude-code)